### PR TITLE
一覧表示ページのデータ表示を改善

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
     <%= link_to post_path(post.id) do %>
       <div class="content_post">
         <%= image_tag post.image.url %>
-        <p><%= post.created_at %></p>
+        <p>【投稿日】<%= l post.created_at, format: :short %></p>
       </div>
     <% end %>
     <p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <h1>投稿一覧</h1>
 <div>
-  <%= @posts.each do |post| %>
+  <% @posts.each do |post| %>
     <p>【投稿者】<%= post.user.name %></p>
     <%= link_to post_path(post.id) do %>
       <div class="content_post">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,14 +3,14 @@
     <% if @post.image? %> 
       <p><%= image_tag @post.image.url%></p>
     <% end %>
-    <p>【名前】<%= @post.user.name %></p>
+    <p>【投稿者】<%= @post.user.name %></p>
     <p>
       <% if current_user.id == @post.user_id %>
         <%= link_to "編集", edit_post_path(@post) %>
         <%= link_to "削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" } %>
       <% end %>
     </p>
-    <p>【投稿日】 <%= l @post.created_at %></p>
+    <p>【投稿日】 <%= l @post.created_at, format: :short %></p>
     <% if @post.body.nil? %>
       <%= @post.body %> 
     <% else %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,3 +31,4 @@ ja:
   time:
     formats:
       default: '%Y年%-m月%-d日(%a) %-H時%-M分%-S秒'
+      short: '%Y.%m.%d  %H:%M'


### PR DESCRIPTION
close #41 
- 一覧表示下部に表示されるデータを表示されないように改善
- 投稿日の表示を変更
<img width="1126" alt="スクリーンショット 2021-08-19 23 33 55" src="https://user-images.githubusercontent.com/77927517/130087674-3f4dea72-6e99-415c-8884-8035c7f53a93.png">
