### PR TITLE
マイページのいいね一覧のエラーを解消

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -87,10 +87,10 @@
                   </small>
                   <hr>
                   <div class="card-like">
-                    <div class="vertical_like" style="color: red;">
-                      <strong><%= "「いいね」" %></strong>
+                    <div class="vertical_like" style="color: black;">
+                      <strong><%= "#{like.user.name}さんが" %></strong>
                       <i class="far fa-regular fa-thumbs-up"></i>
-                      <strong><%= "しました" %></strong>
+                      <strong><%= "しています" %></strong>
                       <i class="fas fa-heart unlike-btn" ></i>
                       <%= like.post.likes.count %>
                     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -72,7 +72,7 @@
         <% @likes.each do |like| %>
           <div class="col-12 col-md-6 col-lg-4 tab-card-container">
             <div class="card tab-content-card border-dark mb-3">
-              <%= link_to post_path(like.post.user.id), class:"abc" do %>
+              <%= link_to post_path(like.post.id), class:"abc" do %>
                 <div class="card-header p-1">
                   <%= image_tag like.post.image.url, class: 'card-img-tab'%>
                 </div>


### PR DESCRIPTION
close #67 
- いいね一覧の記事クリック時のパスのエラー解消
- いいね一覧の記事の「いいねしています」の表記を変更
<img width="1133" alt="スクリーンショット 2021-09-15 0 52 57" src="https://user-images.githubusercontent.com/77927517/133291819-582149ad-bbd1-4465-9873-2227696bdb26.png">
