### PR TITLE
アカウント編集機能の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile])
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :image])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,4 +4,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def ensure_normal_user
     redirect_to root_path, alert: "ゲストユーザーの更新・削除はできません。" if resource.email == "guest@example.com"
   end
+
+  protected
+
+  # アカウント編集後、プロフィール画面に移動する
+  def after_update_path_for(_resource)
+    user_path(id: current_user.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,10 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
   mount_uploader :image, ImageUploader
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name, presence: true
 
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,7 +18,12 @@
   </div>
 
   <div class="field">
-    <%= f.label :image, "プロフィール画像" %><br/>
+    <%= "現在のプロフィール画像" %>
+    <br>
+    <img src=<%= current_user.image %> class="mypage_icon_image">
+    <br>
+    <p></p>
+    <%= f.label :image, "プロフィール画像変更" %><br/>
     <%= f.file_field :image %>
   </div>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -145,4 +145,15 @@ ja:
       not_locked: はロックされていません。
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
-        other: '%{count} 件のエラーが発生したため %{resource} は保存されませんでした。'
+        other: '%{count} 件のエラーが発生したため今回の編集は保存されませんでした。'
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_whitelist_error: '%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}'
+      extension_blacklist_error: '%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}'
+      content_type_whitelist_error: '%{content_type}ファイルのアップロードは許可されていません'
+      content_type_blacklist_error: '%{content_type}ファイルのアップロードは許可されていません'
+      rmagick_processing_error: 'rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}'
+      mini_magick_processing_error: 'MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}'
+      min_size_error: 'ファイルを%{min_size}バイト以上のサイズにしてください'
+      max_size_error: 'ファイルを%{max_size}バイト以下のサイズにしてください'


### PR DESCRIPTION
close #58 
- name, imageカラムのアカウント編集が行えるように修正
- アカウント編集時に現在のプロフィール画像が表示されるよう実
<img width="1148" alt="スクリーンショット 2021-09-18 17 09 42" src="https://user-images.githubusercontent.com/77927517/133881802-54661801-d477-45a6-aa20-eb3f68dfbfaf.png">
装
